### PR TITLE
Fix escape for passwords with single quote

### DIFF
--- a/src/PluggableStrategies/Fillers/FillPasswordInputs.ts
+++ b/src/PluggableStrategies/Fillers/FillPasswordInputs.ts
@@ -35,7 +35,8 @@ export class FillPasswordInputs extends Filler<{}> {
       return Promise.resolve();
     }
     const args = [password];
-    const code = `(${fillPasswordInputs.toString()}).apply(null, JSON.parse('${JSON.stringify(args)}')); `;
+    const code = `(${fillPasswordInputs.toString()}).apply(null, JSON.parse('${JSON.stringify(args)
+        .replace("'", "\\'")}')); `;
     return browser.tabs.executeScript(activeTab.id, {code}).then(() => void 0);
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,7 @@
   "rules": {
     "no-console": [true, "log"],
     "interface-name": false,
-    "quotemark": [true, "single", "jsx-double", "avoid-template"],
+    "quotemark": [true, "single", "jsx-double", "avoid-template", "avoid-escape"],
     "object-literal-sort-keys": false,
     "no-empty-interface": false,
     "no-namespace": false,


### PR DESCRIPTION
Passwords that include single quotes led to invalid json
Escaping single quotes with a backslash solves the problem