### PR TITLE
Add prefix file format

### DIFF
--- a/src/PluggableStrategies/FileFormats/PrefixFileFormat/OptionsPanel.tsx
+++ b/src/PluggableStrategies/FileFormats/PrefixFileFormat/OptionsPanel.tsx
@@ -1,0 +1,65 @@
+import {Checkbox, FormControl, FormControlLabel, FormLabel, TextField} from 'material-ui';
+import {default as Radio, RadioGroup} from 'material-ui/Radio';
+import * as React from 'react';
+import {OptionPanelProps} from 'Options/OptionsReceiver';
+import {Options} from './PrefixFileFormat';
+
+export function OptionsPanel({options, updateOptions}: OptionPanelProps<Options>): JSX.Element {
+  return (
+    <div>
+      <FormControl>
+          <FormControlLabel
+              control={
+                  <Checkbox
+                      checked={options.passwordFirstLine}
+                      onChange={(event: React.ChangeEvent<HTMLInputElement>, isChecked: boolean) => {
+                          updateOptions({
+                              ...options,
+                              passwordFirstLine: isChecked,
+                          });
+                      }}
+                  />
+              }
+              label="Password is in first line (without prefix)"
+          />
+          <TextField
+              id="passwordPrefix"
+              label="PasswordPrefix"
+              value={options.passwordPrefix}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  updateOptions({
+                      ...options,
+                      passwordPrefix: event.target.value,
+                  });
+              }}
+              disabled={options.passwordFirstLine}
+          />
+          <TextField
+              id="passwordPrefix"
+              label="PasswordPrefix"
+              value={options.usernamePrefix}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  updateOptions({
+                      ...options,
+                      usernamePrefix: event.target.value,
+                  });
+              }}
+          />
+          <FormControlLabel
+              control={
+                  <Checkbox
+                      checked={options.trimWhitespace}
+                      onChange={(event: React.ChangeEvent<HTMLInputElement>, isChecked: boolean) => {
+                          updateOptions({
+                              ...options,
+                              trimWhitespace: isChecked,
+                          });
+                      }}
+                  />
+              }
+              label="Trim whitespace"
+          />
+      </FormControl>
+    </div>
+  );
+}

--- a/src/PluggableStrategies/FileFormats/PrefixFileFormat/PrefixFileFormat.ts
+++ b/src/PluggableStrategies/FileFormats/PrefixFileFormat/PrefixFileFormat.ts
@@ -1,0 +1,47 @@
+import {Service} from 'typedi';
+import {OptionsPanelType} from 'Options/OptionsReceiver';
+import {FileFormat, FileFormatTag} from '../';
+import {OptionsPanel} from './OptionsPanel';
+
+export interface Options {
+  passwordFirstLine: boolean;
+  passwordPrefix: string;
+  usernamePrefix: string;
+  trimWhitespace: boolean;
+}
+
+@Service({tags: [FileFormatTag]})
+export class PrefixFileFormat extends FileFormat<Options> {
+  public readonly defaultOptions: Options = {
+    passwordFirstLine: true,
+    passwordPrefix: '',
+    usernamePrefix: 'login:',
+    trimWhitespace: true,
+  };
+  public readonly OptionsPanel: OptionsPanelType<Options> = OptionsPanel;
+  public readonly name: string = PrefixFileFormat.name;
+
+  public getPassword(lines: string[], entryName: string): string | undefined {
+    if (this.options.passwordFirstLine) {
+      return lines[0];
+    }
+    return this.getEntryByPrefix(lines, this.options.passwordPrefix);
+  }
+
+  public getUsername(lines: string[], entryName: string): string | undefined {
+    return this.getEntryByPrefix(lines, this.options.usernamePrefix);
+  }
+
+  private getEntryByPrefix(lines: string[], prefix: string): string | undefined {
+    for (const line of lines) {
+      if (line.startsWith(prefix)) {
+        let entry = line.substr(prefix.length);
+        if (this.options.trimWhitespace) {
+          entry = entry.trim();
+        }
+        return entry;
+      }
+    }
+    return;
+  }
+}

--- a/src/PluggableStrategies/FileFormats/PrefixFileFormat/index.ts
+++ b/src/PluggableStrategies/FileFormats/PrefixFileFormat/index.ts
@@ -1,0 +1,1 @@
+export {PrefixFileFormat} from './PrefixFileFormat';

--- a/src/PluggableStrategies/FileFormats/index.ts
+++ b/src/PluggableStrategies/FileFormats/index.ts
@@ -1,3 +1,4 @@
 export {FileFormat, FileFormatTag} from './FileFormat';
 
 import './FirstLineFileFormat';
+import './PrefixFileFormat';


### PR DESCRIPTION
The case that password is in the first line is handled separately. Further trimming of passwords is also possible and enabled by default such that a whitespace after the prefix does not need to be included in the prefix option. All options are configurable by the user.