### PR TITLE
set min-width on options dialog, closes #38

### DIFF
--- a/src/Options/style.scss
+++ b/src/Options/style.scss
@@ -1,0 +1,3 @@
+body {
+    min-width: 700px;
+}


### PR DESCRIPTION
Possible solution to #38, works at least good enough for me :-)

... and still looks good on Desktop Firefox.  Haven't tried with mobile devices (however those aren't very likely targets for the extension anyways)